### PR TITLE
Add MaaS system id in response

### DIFF
--- a/ansible_inventory_server/maasrest.py
+++ b/ansible_inventory_server/maasrest.py
@@ -44,6 +44,7 @@ class MaasRequestHandler(ApiRequestHandler):
 class MaasMachinesHandler(MaasRequestHandler):
     async def create_response(self, client):
         return [{
+            'system_id': m.system_id,
             'fqdn': m.fqdn,
             'hostname': m.hostname,
             'ip_addresses': m.ip_addresses,


### PR DESCRIPTION
## Proposed feature

Updated `GET /maas/machines` results to also include the MaaS system id for each machine.

## Use case

MaaS uses a `system_id` field to uniquely identify a single machine. When trying to use Ansible Inventory Server with other scripts that work with MaaS, it is useful to know the system id of the machine.