### PR TITLE
Add parameter for choosing subnet for returned IP addresses

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,5 +1,13 @@
 # Ansible Inventory Server API
 
+## Common parameters for all endpoints
+
+| Parameter    | Type          | Description                                                                                                                                                                            | Example          |
+|--------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
+| subnet       | String        | For machines with multiple IP addresses, return the addresses of a specific subnet only. If machine has no IP address on this subnet, then one of its IP addresses is chosen at random | `"10.0.0.0/16"`  |
+| subnet_force | Boolean       | Ignore machines that have no IP addresses in the specified `subnet`                                                                                                                    | `true`           |
+
+
 ## Juju endpoints
 
 Common parameters for all Juju endpoints:

--- a/ansible_inventory_server/config/config.yml
+++ b/ansible_inventory_server/config/config.yml
@@ -1,0 +1,3 @@
+juju:
+  controller_endpoint:
+  model_uuid:

--- a/ansible_inventory_server/maasrest.py
+++ b/ansible_inventory_server/maasrest.py
@@ -17,16 +17,19 @@ from collections import defaultdict
 
 from maas.client.bones import SessionAPI
 
-from ansible_inventory_server.utils import ApiRequestHandler
+from ansible_inventory_server.utils import (ApiRequestHandler,
+                                            filter_ip_addresses)
 
 
-def filter_maas_machine_info(machine):
+def filter_maas_machine_info(machine, kwargs):
     """Keeps only useful machine information"""
+    ip_addresses = filter_ip_addresses(machine['ip_addresses'], kwargs)
+
     return {
         'system_id': machine['system_id'],
         'fqdn': machine['fqdn'],
         'hostname': machine['hostname'],
-        'ip_addresses': machine['ip_addresses'],
+        'ip_addresses': ip_addresses,
         'tags': machine['tag_names']
     }
 
@@ -75,7 +78,7 @@ class MaasMachinesHandler(MaasRequestHandler):
         machines = await self.get_machines(session)
         result = []
         for machine in machines:
-            result.append(filter_maas_machine_info(machine))
+            result.append(filter_maas_machine_info(machine, self.json))
 
         return result
 
@@ -84,10 +87,9 @@ class MaasInventoryHandler(MaasRequestHandler):
     async def create_response(self, session):
         result = defaultdict(lambda: [])
         for m in await self.get_machines(session):
-            if not m['ip_addresses']:
-                continue
+            ip_addresses = filter_ip_addresses(m['ip_addresses'], self.json)
 
             for t in m['tag_names']:
-                result[t].append(m['ip_addresses'][0])
+                result[t].append(ip_addresses[0])
 
         return result

--- a/ansible_inventory_server/maasrest.py
+++ b/ansible_inventory_server/maasrest.py
@@ -23,13 +23,11 @@ from ansible_inventory_server.utils import (ApiRequestHandler,
 
 def filter_maas_machine_info(machine, kwargs):
     """Keeps only useful machine information"""
-    ip_addresses = filter_ip_addresses(machine['ip_addresses'], kwargs)
-
     return {
         'system_id': machine['system_id'],
         'fqdn': machine['fqdn'],
         'hostname': machine['hostname'],
-        'ip_addresses': ip_addresses,
+        'ip_addresses': filter_ip_addresses(machine['ip_addresses'], kwargs),
         'tags': machine['tag_names']
     }
 
@@ -88,6 +86,8 @@ class MaasInventoryHandler(MaasRequestHandler):
         result = defaultdict(lambda: [])
         for m in await self.get_machines(session):
             ip_addresses = filter_ip_addresses(m['ip_addresses'], self.json)
+            if not ip_addresses:
+                continue
 
             for t in m['tag_names']:
                 result[t].append(ip_addresses[0])

--- a/ansible_inventory_server/utils.py
+++ b/ansible_inventory_server/utils.py
@@ -48,6 +48,7 @@ class ApiRequestHandler(tornado.web.RequestHandler):
 
         self.write(response)
 
+
 def filter_ip_addresses(ip_addresses, kwargs):
     """Given a list of @ip_addresses, choose the addresses  @kwargs['subnet'].
     If there are not any, then return the first ip_address"""

--- a/ansible_inventory_server/utils.py
+++ b/ansible_inventory_server/utils.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from ipaddress import ip_network
 import json
 
 import tornado.web
@@ -47,26 +48,16 @@ class ApiRequestHandler(tornado.web.RequestHandler):
 
         self.write(response)
 
-
-def _ip_bits(ip):
-    """'127.0.0.1'  -->  '01111111000000000000000000000001'"""
-    ip = ip.split('/')[0]
-    return ''.join(bin(int(byte))[2:].rjust(8, '0') for byte in ip.split('.'))
-
-
-def ip_in_subnet(ip, subnet):
-    subnet_ip, length = subnet.split('/')
-    return _ip_bits(ip)[:int(length)] == _ip_bits(subnet_ip)[:int(length)]
-
-
 def filter_ip_addresses(ip_addresses, kwargs):
     """Given a list of @ip_addresses, choose the addresses  @kwargs['subnet'].
     If there are not any, then return the first ip_address"""
 
     subnet = kwargs.get('subnet')
     try:
-        result = [ip for ip in ip_addresses if ip_in_subnet(ip, subnet)]
-    except (TypeError, ValueError, IndexError, AttributeError):
+        result = [ip for ip in ip_addresses
+                  if ip_network(ip).overlaps(ip_network(subnet))]
+
+    except ValueError:
         result = ip_addresses
 
     if not result and ip_addresses and not kwargs.get('subnet_force'):

--- a/scripts/juju_inventory_script.py
+++ b/scripts/juju_inventory_script.py
@@ -21,6 +21,9 @@ import sys
 from urllib.request import urlopen, Request
 
 
+SUBNET = '0.0.0.0/0'
+
+
 def main():
     try:
         # For no arguments, or just --list, just output the inventory.
@@ -32,7 +35,8 @@ def main():
                     'username': os.getenv('JUJU_USERNAME'),
                     'password': os.getenv('JUJU_PASSWORD'),
                     'model_uuid': os.getenv('JUJU_MODEL_UUID'),
-                }
+                },
+                'subnet': SUBNET
             }
 
             # optional parameter, Juju certificate

--- a/scripts/juju_inventory_script.py
+++ b/scripts/juju_inventory_script.py
@@ -21,7 +21,7 @@ import sys
 from urllib.request import urlopen, Request
 
 
-SUBNET = '0.0.0.0/0'
+DEFAULT_SUBNET = '10.0.0.0/16'
 
 
 def main():
@@ -36,7 +36,7 @@ def main():
                     'password': os.getenv('JUJU_PASSWORD'),
                     'model_uuid': os.getenv('JUJU_MODEL_UUID'),
                 },
-                'subnet': SUBNET
+                'subnet': os.getenv('SUBNET', DEFAULT_SUBNET)
             }
 
             # optional parameter, Juju certificate

--- a/scripts/maas_inventory_script.py
+++ b/scripts/maas_inventory_script.py
@@ -21,7 +21,7 @@ import sys
 from urllib.request import urlopen, Request
 
 
-SUBNET = '0.0.0.0/0'
+DEFAULT_SUBNET = '10.0.0.0/16'
 
 
 def main():
@@ -35,7 +35,7 @@ def main():
                     'url': os.getenv('MAAS_URL'),
                     'apikey': os.getenv('MAAS_APIKEY'),
                 },
-                'subnet': SUBNET
+                'subnet': os.getenv('SUBNET', DEFAULT_SUBNET)
             }
 
             req = Request('{}/maas/inventory'.format(os.getenv('AIS_URL')),

--- a/scripts/maas_inventory_script.py
+++ b/scripts/maas_inventory_script.py
@@ -21,6 +21,9 @@ import sys
 from urllib.request import urlopen, Request
 
 
+SUBNET = '0.0.0.0/0'
+
+
 def main():
     try:
         # For no arguments, or just --list, just output the inventory.
@@ -31,7 +34,8 @@ def main():
                 'maas': {
                     'url': os.getenv('MAAS_URL'),
                     'apikey': os.getenv('MAAS_APIKEY'),
-                }
+                },
+                'subnet': SUBNET
             }
 
             req = Request('{}/maas/inventory'.format(os.getenv('AIS_URL')),


### PR DESCRIPTION
Added support for a `subnet` parameter. Using that, the API consumer can choose which IP addresses of the machines to use for the inventory scripts.