### PR TITLE
Update MaaS API options

### DIFF
--- a/ansible_inventory_server/maasrest.py
+++ b/ansible_inventory_server/maasrest.py
@@ -80,6 +80,10 @@ class MaasRequestHandler(ApiRequestHandler):
 class MaasMachinesHandler(MaasRequestHandler):
     async def create_response(self, session):
         machines = await MaasMachines.get(session, self.json)
+
+        if (self.json.get('maas') or {}).get('raw'):
+            return machines
+
         result = []
         for machine in machines:
             result.append(filter_maas_machine_info(machine, self.json))


### PR DESCRIPTION
The following changes have been made:

* Move the logic of querying the MaaS API to a request-agnostic class, so that it may be reused from other modules
* Add `maas.no_cache` option to prevent returning cached response.
* Add `maaas.raw` option to return raw response from the MaaS API for the `GET /maas/machines` endpoint.
* Add `parent` field for MaaS machines, in order to be able to identify virtual machines from bare-metal servers.