### PR TITLE
Add support for choosing IP address using interface name

### DIFF
--- a/ansible_inventory_server/jujurest.py
+++ b/ansible_inventory_server/jujurest.py
@@ -64,17 +64,20 @@ async def get_juju_status(parameters):
 def juju_filter_ip_addresses(data, kwargs):
     """Filters IP addresses using network interface name and/or subnet"""
 
-    all_ips = data.get('ip-addresses', [])
+    ip_addresses = []
 
     try:
-        inet_name = kwargs.get('interface')
-        if inet_name:
-            inet_ips = data['network-interfaces'][inet_name]['ip-addresses']
-            all_ips = list(set(all_ips).intersection(set(inet_ips)))
+        interface_filter = kwargs.get('interface')
+        for interface, interface_data in data['network-interfaces']:
+            if interface_filter and interface != interface_filter:
+                continue
+
+            ip_addresses.extend(interface_data.get('ip-addresses') or [])
+
     except (KeyError, ValueError):
         pass
 
-    return filter_ip_addresses(all_ips, kwargs)
+    return filter_ip_addresses(ip_addresses, kwargs)
 
 
 def juju_filter_machine_info(machine, data, kwargs):

--- a/ansible_inventory_server/jujurest.py
+++ b/ansible_inventory_server/jujurest.py
@@ -61,20 +61,21 @@ async def get_juju_status(parameters):
     return status
 
 
-def juju_filter_ip_addresses(data, kwargs):
-    """Filters IP addresses using network interface name and/or subnet"""
+def juju_filter_ip_addresses(interfaces, kwargs):
+    """Filters IP addresses from Juju network interfaces, optionally with
+    interface name and subnet."""
 
     ip_addresses = []
 
     try:
         interface_filter = kwargs.get('interface')
-        for interface, interface_data in data['network-interfaces']:
+        for interface, interface_data in interfaces.items():
             if interface_filter and interface != interface_filter:
                 continue
 
             ip_addresses.extend(interface_data.get('ip-addresses') or [])
 
-    except (KeyError, ValueError):
+    except (ValueError, AttributeError):
         pass
 
     return filter_ip_addresses(ip_addresses, kwargs)
@@ -86,7 +87,8 @@ def juju_filter_machine_info(machine, data, kwargs):
         'id': machine,
         'name': data.get('display-name') or data.get('instance-id'),
         'instance_id': data.get('instance-id'),
-        'ip_addresses': juju_filter_ip_addresses(data, kwargs),
+        'ip_addresses': juju_filter_ip_addresses(
+            data.get('network-interfaces') or {}, kwargs),
         'apps': [],
         'subordinates': [],
         'containers': [],

--- a/ansible_inventory_server/maasrest.py
+++ b/ansible_inventory_server/maasrest.py
@@ -25,24 +25,22 @@ from ansible_inventory_server.utils import (ApiRequestHandler,
 def maas_filter_ip_addresses(data, kwargs):
     """Filters IP addresses using network interface name and/or subnet"""
 
-    all_ips = data.get('ip_addresses', [])
+    ip_addresses = []
 
     try:
-        inet_name = kwargs.get('interface')
-        if inet_name:
-            for interface in data['interface_set']:
-                if interface['name'] == inet_name:
-                    links = interface.get('links') or []
-                    links += interface.get('discovered') or []
-                    inet_ips = [link['ip_address'] for link in links]
-                    break
+        interface_filter = kwargs.get('interface')
+        for interface in data['interface_set']:
+            if interface_filter and interface['name'] != interface_filter:
+                continue
 
-        all_ips = list(set(all_ips).intersection(set(inet_ips)))
+            links = interface.get('links') or []
+            links += interface.get('discovered') or []
+            ip_addresses.extend([link['ip_address'] for link in links])
 
     except (KeyError, NameError):
         pass
 
-    return filter_ip_addresses(all_ips, kwargs)
+    return filter_ip_addresses(ip_addresses, kwargs)
 
 def filter_maas_machine_info(machine, kwargs):
     """Keeps only useful machine information"""

--- a/ansible_inventory_server/maasrest.py
+++ b/ansible_inventory_server/maasrest.py
@@ -21,7 +21,6 @@ from ansible_inventory_server.utils import (ApiRequestHandler,
                                             filter_ip_addresses)
 
 
-
 def maas_filter_ip_addresses(data, kwargs):
     """Filters IP addresses using network interface name and/or subnet"""
 
@@ -41,6 +40,7 @@ def maas_filter_ip_addresses(data, kwargs):
         pass
 
     return filter_ip_addresses(ip_addresses, kwargs)
+
 
 def filter_maas_machine_info(machine, kwargs):
     """Keeps only useful machine information"""


### PR DESCRIPTION
As discussed in #13, filtering IP addresses by subnet may not be enough, because Virtual IPs may be returned.

Adding a new option `interface`, that can filter IP addresses for a machine by interface name. E.g.:

```
$ curl localhost:5000/juju/inventory -d "{${JUJUK}, \"subnet\": \"10.1.0.0/16\"}" -XGET
{"_meta": {"hostvars": {"10.1.0.1": {}, "10.1.0.100": {}, "10.1.0.3": {}}}, "openstack": {"children": ["keystone"]}, "keystone": {"hosts": ["10.1.0.1", "10.1.0.100", "10.1.0.3"]}}

$ curl localhost:5000/juju/inventory -d "{${JUJUK}, \"interface\": \"eth2\"}" -XGET
{"_meta": {"hostvars": {"10.1.0.1": {}, "10.1.0.2": {}, "10.1.0.3": {}}}, "openstack": {"children": ["keystone"]}, "keystone": {"hosts": ["10.1.0.1", "10.1.0.2", "10.1.0.3"]}}
```
