### PR TITLE
Use Juju machine name as hostname instead of IP address

### DIFF
--- a/ansible_inventory_server/jujurest.py
+++ b/ansible_inventory_server/jujurest.py
@@ -149,15 +149,16 @@ class JujuInventoryHandler(JujuRequestHandler):
             if not machine_data['ip_addresses']:
                 continue
 
-            address = machine_data['ip_addresses'][0]
-
+            name = machine_data['name']
             for app in machine_data['apps']:
                 if app not in result:
                     result[app] = {'hosts': []}
                     result[status.model.name]['children'].append(app)
 
-                result[app]['hosts'].append(address)
-                result['_meta']['hostvars'][address] = {}
+                result[app]['hosts'].append(name)
+                result['_meta']['hostvars'][name] = {
+                    'ansible_host': machine_data['ip_addresses'][0],
+                }
 
         return result
 


### PR DESCRIPTION
This proposed change uses the Juju machine name (`hostname` for bare metal servers, `juju-MODEL-MACHINEID-HASH` for containers) instead of the IP address as the Ansible hostname.

In environments with large numbers of Juju hosts, this makes identifying each server much easier (currently, one has to deduce each machine from its IP address when looking at the Ansible logs).

We also set the `ansible_host` variable, to ensure that the proper IP address is used by Ansible for connecting to the host. Thus, no operational changes in this PR.
